### PR TITLE
Fixed characters stopping even if boosted.

### DIFF
--- a/src/elements/CharacterStates.ts
+++ b/src/elements/CharacterStates.ts
@@ -82,6 +82,15 @@ export abstract class CharacterStateBase extends State implements UpdateHandler 
     }
 
     stopMoving() {
+
+        const thisBody = this.stateMachine.body.body;
+        const forwardDirection = Helpers.forwardVector.applyQuaternion(thisBody.getRotation());
+        let currentVelo = thisBody.getVelocity().clone().projectOnVector(forwardDirection).length();
+        const threshold = 0.5;
+
+        if (currentVelo > this.movementSpeed+threshold)
+            return;
+
         let newVelo = Helpers.zeroVector;
 
         if (!this.has3DMovement)


### PR DESCRIPTION
If it occurs that a non-player character steps on a boosting-area while it's switching to a state that requires it to stop (say: idle), boosters won't affect them. This is a fix for that.